### PR TITLE
Update init so that sys.executable points to python

### DIFF
--- a/c_src/pythonx/python.cpp
+++ b/c_src/pythonx/python.cpp
@@ -77,6 +77,7 @@ DEF_SYMBOL(Py_IsFalse)
 DEF_SYMBOL(Py_IsNone)
 DEF_SYMBOL(Py_IsTrue)
 DEF_SYMBOL(Py_SetPythonHome)
+DEF_SYMBOL(Py_SetProgramName)
 
 dl::LibraryHandle python_library;
 
@@ -150,6 +151,7 @@ void load_python_library(std::string path) {
   LOAD_SYMBOL(python_library, Py_IsNone)
   LOAD_SYMBOL(python_library, Py_IsTrue)
   LOAD_SYMBOL(python_library, Py_SetPythonHome)
+  LOAD_SYMBOL(python_library, Py_SetProgramName)
 }
 
 void unload_python_library() {

--- a/c_src/pythonx/python.hpp
+++ b/c_src/pythonx/python.hpp
@@ -131,6 +131,7 @@ extern int (*Py_IsFalse)(PyObjectPtr);
 extern int (*Py_IsNone)(PyObjectPtr);
 extern int (*Py_IsTrue)(PyObjectPtr);
 extern void (*Py_SetPythonHome)(const wchar_t *);
+extern void (*Py_SetProgramName)(const wchar_t *);
 
 // Opens Python dynamic library at the given path and looks up all
 // relevant symbols.

--- a/lib/pythonx.ex
+++ b/lib/pythonx.ex
@@ -12,47 +12,6 @@ defmodule Pythonx do
 
   @type encoder :: (term(), encoder() -> Object.t())
 
-  @doc """
-  Initializes the Python interpreter.
-
-  > #### Reproducability {: .info}
-  >
-  > This function can be called to use a custom Python installation,
-  > however in most cases it is more convenient to call `uv_init/2`,
-  > which installs Python and dependencies, and then automatically
-  > initializes the interpreter using the correct paths.
-
-  The `python_dl_path` argument is the Python dynamically linked
-  library file. The usual file name is `libpython3.x.so` (Linux),
-  `libpython3.x.dylib` (macOS), `python3x.dll` (Windows).
-
-  The `python_home_path` is the Python home directory, where the Python
-  built-in modules reside. Specifically, the modules should be located
-  in `{python_home_path}/lib/pythonx.y` (Linux and macOS) or
-  `{python_home_path}/Lib` (Windows).
-
-  ## Options
-
-    * `:sys_paths` - directories to be added to the module search path
-      (`sys.path`). Defaults to `[]`.
-
-  """
-  @spec init(String.t(), String.t(), keyword()) :: :ok
-  def init(python_dl_path, python_home_path, opts \\ [])
-      when is_binary(python_dl_path) and is_binary(python_home_path) and is_list(opts) do
-    opts = Keyword.validate!(opts, sys_paths: [])
-
-    if not File.exists?(python_dl_path) do
-      raise ArgumentError, "the given dynamic library file does not exist: #{python_dl_path}"
-    end
-
-    if not File.dir?(python_home_path) do
-      raise ArgumentError, "the given python home directory does not exist: #{python_home_path}"
-    end
-
-    Pythonx.NIF.init(python_dl_path, python_home_path, opts[:sys_paths])
-  end
-
   @doc ~S'''
   Installs Python and dependencies using [uv](https://docs.astral.sh/uv)
   package manager and initializes the interpreter.
@@ -97,6 +56,53 @@ defmodule Pythonx do
 
     Pythonx.Uv.fetch(pyproject_toml, false, opts)
     Pythonx.Uv.init(pyproject_toml, false)
+  end
+
+  # Initializes the Python interpreter.
+  #
+  # > #### Reproducability {: .info}
+  # >
+  # > This function can be called to use a custom Python installation,
+  # > however in most cases it is more convenient to call `uv_init/2`,
+  # > which installs Python and dependencies, and then automatically
+  # > initializes the interpreter using the correct paths.
+  #
+  # `python_dl_path` is the Python dynamically linked library file.
+  # The usual file name is `libpython3.x.so` (Linux), `libpython3.x.dylib`
+  # (macOS), `python3x.dll` (Windows).
+  #
+  # `python_home_path` is the Python home directory, where the Python
+  # built-in modules reside. Specifically, the modules should be
+  # located in `{python_home_path}/lib/pythonx.y` (Linux and macOS)
+  # or `{python_home_path}/Lib` (Windows).
+  #
+  # `python_executable_path` is the Python executable file.
+  #
+  # ## Options
+  #
+  #   * `:sys_paths` - directories to be added to the module search path
+  #     (`sys.path`). Defaults to `[]`.
+  #
+  @doc false
+  @spec init(String.t(), String.t(), keyword()) :: :ok
+  def init(python_dl_path, python_home_path, python_executable_path, opts \\ [])
+      when is_binary(python_dl_path) and is_binary(python_home_path)
+      when is_binary(python_executable_path) and is_list(opts) do
+    opts = Keyword.validate!(opts, sys_paths: [])
+
+    if not File.exists?(python_dl_path) do
+      raise ArgumentError, "the given dynamic library file does not exist: #{python_dl_path}"
+    end
+
+    if not File.dir?(python_home_path) do
+      raise ArgumentError, "the given python home directory does not exist: #{python_home_path}"
+    end
+
+    if not File.exists?(python_home_path) do
+      raise ArgumentError, "the given python executable does not exist: #{python_executable_path}"
+    end
+
+    Pythonx.NIF.init(python_dl_path, python_home_path, python_executable_path, opts[:sys_paths])
   end
 
   @doc ~S'''

--- a/lib/pythonx/nif.ex
+++ b/lib/pythonx/nif.ex
@@ -12,7 +12,7 @@ defmodule Pythonx.NIF do
     end
   end
 
-  def init(_python_dl_path, _python_home_path, _sys_paths), do: err!()
+  def init(_python_dl_path, _python_home_path, _python_executable_path, _sys_paths), do: err!()
   def terminate(), do: err!()
   def janitor_decref(_ptr), do: err!()
   def none_new(), do: err!()

--- a/lib/pythonx/uv.ex
+++ b/lib/pythonx/uv.ex
@@ -106,12 +106,19 @@ defmodule Pythonx.Uv do
 
         python_home_path = make_windows_slashes(root_dir)
 
+        python_executable_path =
+          abs_executable_dir
+          |> Path.join("python.exe")
+          |> make_windows_slashes()
+
         venv_packages_path =
           project_dir
           |> Path.join(".venv/Lib/site-packages")
           |> make_windows_slashes()
 
-        Pythonx.init(python_dl_path, python_home_path, sys_paths: [venv_packages_path])
+        Pythonx.init(python_dl_path, python_home_path, python_executable_path,
+          sys_paths: [venv_packages_path]
+        )
 
       {:unix, osname} ->
         dl_extension =
@@ -128,12 +135,16 @@ defmodule Pythonx.Uv do
 
         python_home_path = root_dir
 
+        python_executable_path = Path.join(abs_executable_dir, "python")
+
         venv_packages_path =
           project_dir
           |> Path.join(".venv/lib/python3*/site-packages")
           |> wildcard_one!()
 
-        Pythonx.init(python_dl_path, python_home_path, sys_paths: [venv_packages_path])
+        Pythonx.init(python_dl_path, python_home_path, python_executable_path,
+          sys_paths: [venv_packages_path]
+        )
     end
   end
 


### PR DESCRIPTION
When running hf/transformers, during the first time a model is downloaded, I noticed a long message with BEAM executable usage. It turns out that there is a Python module that may spawn another Python OS process when certain shared resources are opened, such as shared memory, semaphores, to make sure the resources are never leaked ([ref](https://github.com/python/cpython/blob/3.13/Lib/multiprocessing/resource_tracker.py#L149-L151)). The issue is that it tries to spawn `sys.executable` (effectively `argv[0]`), which points to the BEAM executable. This PR fixes it, such that it points to a Python executable.

This introduces a breaking change to `Pythonx.init`, and I decided to remove it from the API altogether, until there is an actual use case for it. In practice, I don't see a good reason no to use `Pythonx.uv_init`, especially that getting the paths correctly across OSes can be tricky.