### PR TITLE
Make sure the ~PY sigil does not trigger an unused variable warning

### DIFF
--- a/lib/pythonx.ex
+++ b/lib/pythonx.ex
@@ -290,6 +290,9 @@ defmodule Pythonx do
       for name <- defined do
         quote do
           unquote({String.to_atom(name), [], nil}) = Map.get(globals, unquote(name), nil)
+          # We do an extra underscore assignment to make sure the
+          # generated code does not trigger an unused variable warning.
+          _ = unquote({String.to_atom(name), [], nil})
         end
       end
 

--- a/test/pythonx_test.exs
+++ b/test/pythonx_test.exs
@@ -413,6 +413,25 @@ defmodule PythonxTest do
 
       assert repr(result) == "43"
     end
+
+    test "does not result in unused variables" do
+      {_result, diagnostics} =
+        Code.with_diagnostics(fn ->
+          Code.eval_string(~s'''
+          defmodule TestModule#{System.unique_integer([:positive])} do
+            import Pythonx
+
+            def run() do
+              ~PY"""
+              x = 1
+              """
+            end
+          end
+          ''')
+        end)
+
+      assert diagnostics == []
+    end
   end
 
   defp repr(object) do


### PR DESCRIPTION
When using `~PY` in a module body (in a script), assigning Python variables results in unused variables warning, because the sigil always assigns the corresponding Elixir variables, regardless if they are used later.