### PR TITLE
Do not include undefined Elixir variables in the expanded ~PY sigil

### DIFF
--- a/lib/pythonx.ex
+++ b/lib/pythonx.ex
@@ -285,12 +285,12 @@ defmodule Pythonx do
 
     globals_entries =
       for name <- referenced,
-        name_atom = String.to_atom(name),
-        # We only reference variables that are actually defined. This
-        # way, if an undefined variable is referenced in the Python
-        # code, it results in an informative Python error, rather than
-        # Elixir compile error.
-        Map.has_key?(versioned_vars, {name_atom, nil}) do
+          name_atom = String.to_atom(name),
+          # We only reference variables that are actually defined.
+          # This way, if an undefined variable is referenced in the
+          # Python code, it results in an informative Python error,
+          # rather than Elixir compile error.
+          Map.has_key?(versioned_vars, {name_atom, nil}) do
         {name, {name_atom, [], nil}}
       end
 

--- a/lib/pythonx.ex
+++ b/lib/pythonx.ex
@@ -281,7 +281,7 @@ defmodule Pythonx do
   defmacro sigil_PY({:<<>>, _meta, [code]}, []) when is_binary(code) do
     %{referenced: referenced, defined: defined} = Pythonx.AST.scan_globals(code)
 
-    versioned_vars = __CALLER__.versioned_vars
+    caller = __CALLER__
 
     globals_entries =
       for name <- referenced,
@@ -290,7 +290,7 @@ defmodule Pythonx do
           # This way, if an undefined variable is referenced in the
           # Python code, it results in an informative Python error,
           # rather than Elixir compile error.
-          Map.has_key?(versioned_vars, {name_atom, nil}) do
+          Macro.Env.has_var?(caller, {name_atom, nil}) do
         {name, {name_atom, [], nil}}
       end
 

--- a/test/pythonx_test.exs
+++ b/test/pythonx_test.exs
@@ -386,9 +386,7 @@ defmodule PythonxTest do
           ''',
           []
         )
-
-        end
-
+      end
     end
 
     test "global redefinition" do

--- a/test/pythonx_test.exs
+++ b/test/pythonx_test.exs
@@ -374,6 +374,23 @@ defmodule PythonxTest do
       assert Keyword.keys(binding) == [:x]
     end
 
+    test "results in a Python error when a variable is undefined" do
+      assert_raise Pythonx.Error, ~r/NameError: name 'x' is not defined/, fn ->
+        Code.eval_string(
+          ~S'''
+          import Pythonx
+
+          ~PY"""
+          x + 1
+          """
+          ''',
+          []
+        )
+
+        end
+
+    end
+
     test "global redefinition" do
       {_result, binding} =
         Code.eval_string(
@@ -414,7 +431,7 @@ defmodule PythonxTest do
       assert repr(result) == "43"
     end
 
-    test "does not result in unused variables" do
+    test "does not result in unused variables diagnostics" do
       {_result, diagnostics} =
         Code.with_diagnostics(fn ->
           Code.eval_string(~s'''


### PR DESCRIPTION
Currently when `~PY` references an undefined variable, it results in Elixir compile error, because the expanded AST references the corresponding Elixir variable. This PR changes it, such that we don't generate such AST nodes and let the Python code run and fail. This way we fail later, but provide a more informative error (actually related to the code), including line information.