### PR TITLE
Change sys.executable to python executable inside venv

### DIFF
--- a/lib/pythonx.ex
+++ b/lib/pythonx.ex
@@ -76,7 +76,10 @@ defmodule Pythonx do
   # located in `{python_home_path}/lib/pythonx.y` (Linux and macOS)
   # or `{python_home_path}/Lib` (Windows).
   #
-  # `python_executable_path` is the Python executable file.
+  # `python_executable_path` is the Python executable file. When using
+  # venv, it is preferable to point to an executable in the venv
+  # directory, which is relevant if additional packages are installed
+  # at runtime.
   #
   # ## Options
   #

--- a/lib/pythonx/uv.ex
+++ b/lib/pythonx/uv.ex
@@ -107,8 +107,8 @@ defmodule Pythonx.Uv do
         python_home_path = make_windows_slashes(root_dir)
 
         python_executable_path =
-          abs_executable_dir
-          |> Path.join("python.exe")
+          project_dir
+          |> Path.join(".venv/Scripts/python.exe")
           |> make_windows_slashes()
 
         venv_packages_path =
@@ -135,7 +135,7 @@ defmodule Pythonx.Uv do
 
         python_home_path = root_dir
 
-        python_executable_path = Path.join(abs_executable_dir, "python")
+        python_executable_path = Path.join(project_dir, ".venv/bin/python")
 
         venv_packages_path =
           project_dir


### PR DESCRIPTION
Currently `sys.executable` points to the executable outside of `venv`, so spawning a subprocess using that executable doesn't operate within the venv either.