### PR TITLE
Hide symbols from the NIF shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PRIV_DIR = $(MIX_APP_PATH)/priv
 NIF_PATH = $(PRIV_DIR)/libpythonx.so
 
 C_SRC = $(shell pwd)/c_src/pythonx
-CPPFLAGS = -shared -fPIC -std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-comment
+CPPFLAGS = -shared -fPIC -fvisibility=hidden -std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-comment
 CPPFLAGS += -I$(ERTS_INCLUDE_DIR) -I$(FINE_INCLUDE_DIR)
 
 ifdef DEBUG


### PR DESCRIPTION
This compiles the NIF shared library with `-fvisibility=hidden`, hiding all symbols other than the NIF init required by ERTS. I believe this is a good default for NIFs in general, it avoids symbol clashes (e.g. when multiple NIFs use the same external library, possibly with different versions), and it can also improve performance and linking time.

For more details see https://github.com/elixir-nx/fine/issues/2#issuecomment-2703366091.