### PR TITLE
encode valid strings with unicode_from_string

### DIFF
--- a/lib/pythonx.ex
+++ b/lib/pythonx.ex
@@ -347,7 +347,7 @@ defmodule Pythonx do
 
       iex> Pythonx.encode!({1, true, "hello world"})
       #Pythonx.Object<
-        (1, True, b'hello world')
+        (1, True, 'hello world')
       >
 
   """

--- a/lib/pythonx/encoder.ex
+++ b/lib/pythonx/encoder.ex
@@ -128,7 +128,11 @@ end
 
 defimpl Pythonx.Encoder, for: BitString do
   def encode(term, _encoder) when is_binary(term) do
-    Pythonx.NIF.bytes_from_binary(term)
+    if String.valid?(term) do
+      Pythonx.NIF.unicode_from_string(term)
+    else
+      Pythonx.NIF.bytes_from_binary(term)
+    end
   end
 
   def encode(term, _encoder) do

--- a/test/pythonx_test.exs
+++ b/test/pythonx_test.exs
@@ -25,13 +25,13 @@ defmodule PythonxTest do
     end
 
     test "string" do
-      assert repr(Pythonx.encode!("hello")) == "b'hello'"
+      assert repr(Pythonx.encode!("hello")) == "'hello'"
 
-      assert repr(Pythonx.encode!("🦊 in a 📦")) ==
-               ~S"b'\xf0\x9f\xa6\x8a in a \xf0\x9f\x93\xa6'"
+      assert repr(Pythonx.encode!("🦊 in a 📦")) == ~S"'🦊 in a 📦'"
     end
 
     test "binary" do
+      assert repr(Pythonx.encode!(<<104, 101, 108, 108, 111>>)) == "'hello'"
       assert repr(Pythonx.encode!(<<65, 255>>)) == ~S"b'A\xff'"
 
       assert_raise Protocol.UndefinedError, fn ->
@@ -41,17 +41,22 @@ defmodule PythonxTest do
 
     test "list" do
       assert repr(Pythonx.encode!([])) == "[]"
-      assert repr(Pythonx.encode!([1, 2.0, "hello"])) == "[1, 2.0, b'hello']"
+
+      assert repr(Pythonx.encode!([1, 2.0, "hello", <<65, 255>>])) ==
+               ~S"[1, 2.0, 'hello', b'A\xff']"
     end
 
     test "tuple" do
       assert repr(Pythonx.encode!({})) == "()"
       assert repr(Pythonx.encode!({1})) == "(1,)"
-      assert repr(Pythonx.encode!({1, 2.0, "hello"})) == "(1, 2.0, b'hello')"
+
+      assert repr(Pythonx.encode!({1, 2.0, "hello", <<65, 255>>})) ==
+               ~S"(1, 2.0, 'hello', b'A\xff')"
     end
 
     test "map" do
-      assert repr(Pythonx.encode!(%{"hello" => 1})) == "{b'hello': 1}"
+      assert repr(Pythonx.encode!(%{"hello" => 1})) == "{'hello': 1}"
+      assert repr(Pythonx.encode!(%{<<65, 255>> => 3.14})) == ~S"{b'A\xff': 3.14}"
       assert repr(Pythonx.encode!(%{2 => nil})) == "{2: None}"
     end
 


### PR DESCRIPTION
Thanks for this library! I was surprised when valid strings came through as b-strings on the python side. This feels more natural to me, but if I am missing something, please let me know.