### PR TITLE
Add Pythonx.install_env/0 and Pythonx.install_paths/0 to enable FLAME

### DIFF
--- a/lib/pythonx/application.ex
+++ b/lib/pythonx/application.ex
@@ -31,18 +31,7 @@ defmodule Pythonx.Application do
     Pythonx.Uv.fetch(pyproject_toml, true, opts)
     defp maybe_uv_init(), do: Pythonx.Uv.init(unquote(pyproject_toml), true, unquote(opts))
   else
-    defp maybe_uv_init() do
-      case Pythonx.init_state_from_env() do
-        nil ->
-          :noop
-
-        init_state_env_value ->
-          init_state_env_value
-          |> Base.decode64!()
-          |> :erlang.binary_to_term()
-          |> Pythonx.init()
-      end
-    end
+    defp maybe_uv_init(), do: Pythonx.maybe_init_from_env()
   end
 
   defp enable_sigchld() do


### PR DESCRIPTION
This is a proposition / food for discussion at this point - coming over form the discussion here: https://elixirforum.com/t/is-there-a-way-to-access-pyproject-toml/73129.

In order to support Livebook+Pythonx+FLAME, somethink like this would be a first step. We'd still have to somehow get that struct/data over to the FLAME and initialize Pythonx in Livebook's [`/rel/server/overlays/bin/start_flame.exs`](https://github.com/livebook-dev/livebook/blob/main/rel/server/overlays/bin/start_flame.exs). Since this can only be done once, we can't do it inside the FLAME.call function as FLAMEs can be reused...

WDYT?