### PR TITLE
Support :python option in compile-time config

### DIFF
--- a/lib/pythonx/application.ex
+++ b/lib/pythonx/application.ex
@@ -26,7 +26,8 @@ defmodule Pythonx.Application do
   uv_init_env = Application.compile_env(:pythonx, :uv_init)
   pyproject_toml = uv_init_env[:pyproject_toml]
   uv_version = uv_init_env[:uv_version] || Pythonx.Uv.default_uv_version()
-  opts = [uv_version: uv_version]
+  python = uv_init_env[:python]
+  opts = [uv_version: uv_version, python: python]
 
   if pyproject_toml do
     Pythonx.Uv.fetch(pyproject_toml, true, opts)


### PR DESCRIPTION
## Summary

- The `:python` option (e.g., `"3.14t"` for free-threaded builds) set via `config :pythonx, :uv_init` is read from `Application.compile_env` but never forwarded to `Pythonx.Uv.fetch/3` or `Pythonx.Uv.init/3`
- This causes `uv sync` to download the regular Python build instead of the requested variant

## Context

PR #45 added the `:python` option to `Pythonx.uv_init/2` (the runtime function), which works correctly. However, the compile-time config path in `application.ex` was not updated to forward this option. Users following the recommended Mix project setup via `config :pythonx, :uv_init` silently get the wrong Python variant.

## Change

One line in `lib/pythonx/application.ex` — read `:python` from the config and include it in the opts passed to `fetch/3` and `init/3`:

```elixir
# Before
opts = [uv_version: uv_version]

# After
python = uv_init_env[:python]
opts = [uv_version: uv_version, python: python]
```

## Verification

Tested on macOS aarch64. Before the fix, `config :pythonx, :uv_init, python: "3.14t"` downloads `cpython-3.14.3-macos-aarch64-none` (regular). After the fix, it downloads `cpython-3.14.3+freethreaded-macos-aarch64-none` and confirms GIL disabled.